### PR TITLE
Clean up dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,4 @@ module github.com/m3db/stackmurmur3
 
 go 1.14
 
-require (
-	github.com/spaolacci/murmur3 v1.1.0
-	github.com/stretchr/testify v1.6.1
-)
+require github.com/stretchr/testify v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,6 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
-github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=

--- a/murmur_test.go
+++ b/murmur_test.go
@@ -6,7 +6,6 @@ import (
 	"runtime"
 	"testing"
 
-	murmur3origin "github.com/spaolacci/murmur3"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -109,67 +108,6 @@ func TestIncremental(t *testing.T) {
 			t.Errorf("[Hash128] key: '%s', seed: '%d': 0x%x-0x%x (want 0x%x-0x%x)", elem.s, elem.seed, v1, v2, elem.h64_1, elem.h64_2)
 		}
 	}
-}
-
-//---
-
-func originIncrementalBench128(b *testing.B, length int) {
-	buf := make([]byte, length)
-	b.SetBytes(int64(length))
-	h := murmur3origin.New128()
-	b.ResetTimer()
-
-	for i := 0; i < b.N; i++ {
-		h.Reset()
-		h.Write(buf)
-		h.Sum128()
-		// escape analysis forces this to be heap allocated
-		h.Write([]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15})
-		h.Sum128()
-	}
-}
-
-func Benchmark_Incremental_Origin_128_1(b *testing.B) {
-	originIncrementalBench128(b, 1)
-}
-func Benchmark_Incremental_Origin_128_2(b *testing.B) {
-	originIncrementalBench128(b, 2)
-}
-func Benchmark_Incremental_Origin_128_4(b *testing.B) {
-	originIncrementalBench128(b, 4)
-}
-func Benchmark_Incremental_Origin_128_8(b *testing.B) {
-	originIncrementalBench128(b, 8)
-}
-func Benchmark_Incremental_Origin_128_16(b *testing.B) {
-	originIncrementalBench128(b, 16)
-}
-func Benchmark_Incremental_Origin_128_32(b *testing.B) {
-	originIncrementalBench128(b, 128)
-}
-func Benchmark_Incremental_Origin_128_64(b *testing.B) {
-	originIncrementalBench128(b, 64)
-}
-func Benchmark_Incremental_Origin_128_128(b *testing.B) {
-	originIncrementalBench128(b, 128)
-}
-func Benchmark_Incremental_Origin_128_256(b *testing.B) {
-	originIncrementalBench128(b, 256)
-}
-func Benchmark_Incremental_Origin_128_512(b *testing.B) {
-	originIncrementalBench128(b, 512)
-}
-func Benchmark_Incremental_Origin_128_1024(b *testing.B) {
-	originIncrementalBench128(b, 1024)
-}
-func Benchmark_Incremental_Origin_128_2048(b *testing.B) {
-	originIncrementalBench128(b, 2048)
-}
-func Benchmark_Incremental_Origin_128_4096(b *testing.B) {
-	originIncrementalBench128(b, 4096)
-}
-func Benchmark_Incremental_Origin_128_8192(b *testing.B) {
-	originIncrementalBench128(b, 8192)
 }
 
 func forkedIncrementalBench128(b *testing.B, length int) {


### PR DESCRIPTION
Since I've tagged v2.0.0, we should drop benchmark-only dependency that's quite broken on new Go releases.
Can always revert if needed for testing.